### PR TITLE
New SID Specific Structure

### DIFF
--- a/client/functions/query.py
+++ b/client/functions/query.py
@@ -34,7 +34,7 @@ class QueryClient(object):
       if not sid:
           named_query = self.repo_prefix + [Component.from_str("query")] + query
       else:
-          named_query = self.repo_prefix + [Component.from_str("sid-query")] + [Component.from_str(sid)] + query
+          named_query = self.repo_prefix + [Component.from_str("sid")] + [Component.from_str(sid)] + [Component.from_str("query")] + query
 
       try:
           data_name, meta_info, content = await self.app.express_interest(named_query, can_be_prefix=True, must_be_fresh=True, lifetime=3000)

--- a/ndn_distributed_repo/handle_protocol/query_handle.py
+++ b/ndn_distributed_repo/handle_protocol/query_handle.py
@@ -22,11 +22,11 @@ class QueryHandle(object):
         self.session_id = config['session_id']
         self.repo_prefix = config['repo_prefix']
 
-        self.normal_serving_comp = "/query"
-        self.personal_serving_comp = "/sid-query"
+        self.command_comp = "/query"
+        self.sid_comp = "/sid"
 
-        self.listen(Name.from_str(self.repo_prefix + self.normal_serving_comp))
-        self.listen(Name.from_str(self.repo_prefix + self.personal_serving_comp  + "/" + self.session_id))
+        self.listen(Name.from_str(self.repo_prefix + self.command_comp))
+        self.listen(Name.from_str(self.repo_prefix + self.sid_comp  + "/" + self.session_id + self.command_comp))
 
     def listen(self, prefix):
         """
@@ -110,7 +110,7 @@ class QueryHandle(object):
 
     def _get_query_from_interest(self, int_name):
         query = int_name[len(self.repo_prefix):]
-        if query[0:len(self.normal_serving_comp)] == self.normal_serving_comp:
-            return query[len(self.normal_serving_comp):]
+        if query[0:len(self.sid_comp)] == self.sid_comp:
+            return query[(len(self.sid_comp)+len("/" + self.session_id)+len(self.command_comp)):]
         else:
-            return query[(len(self.personal_serving_comp)+len("/" + self.session_id)):]
+            return query[(len(self.command_comp)):]

--- a/ndn_distributed_repo/handle_protocol/read_handle.py
+++ b/ndn_distributed_repo/handle_protocol/read_handle.py
@@ -25,11 +25,11 @@ class ReadHandle(object):
         self.session_id = config['session_id']
         self.repo_prefix = config['repo_prefix']
 
-        self.normal_serving_comp = "/fetch"
-        self.personal_serving_comp = "/sid-fetch"
+        self.command_comp = "/fetch"
+        self.sid_comp = "/sid"
 
-        self.listen(Name.from_str(self.repo_prefix + self.normal_serving_comp))
-        self.listen(Name.from_str(self.repo_prefix + self.personal_serving_comp  + "/" + self.session_id))
+        self.listen(Name.from_str(self.repo_prefix + self.command_comp))
+        self.listen(Name.from_str(self.repo_prefix + self.sid_comp  + "/" + self.session_id + self.command_comp))
 
     def listen(self, prefix):
         """
@@ -86,7 +86,7 @@ class ReadHandle(object):
                 print(f'[cmd][FETCH] linked to another node in the repo')
 
             # create a link to a node who has the content
-            new_name = self.repo_prefix + self.personal_serving_comp + "/" + best_id + file_name
+            new_name = self.repo_prefix + self.sid_comp + "/" + best_id + self.command_comp + file_name
             link_content = bytes(new_name.encode())
             final_id = Component.from_number(int(self.global_view.get_insertion_by_file_name(file_name)["packets"])-1, Component.TYPE_SEGMENT)
             self.app.put_data(int_name, content=link_content, content_type=ContentType.LINK, final_block_id=final_id)
@@ -95,10 +95,10 @@ class ReadHandle(object):
 
     def _get_file_name_from_interest(self, int_name):
         file_name = int_name[len(self.repo_prefix):]
-        if file_name[0:len(self.normal_serving_comp)] == self.normal_serving_comp:
-            return file_name[len(self.normal_serving_comp):]
+        if file_name[0:len(self.sid_comp)] == self.sid_comp:
+            return file_name[(len(self.sid_comp)+len("/" + self.session_id)+len(self.command_comp)):]
         else:
-            return file_name[(len(self.personal_serving_comp)+len("/" + self.session_id)):]
+            return file_name[(len(self.command_comp)):]
 
     def _best_id_for_file(self, file_name: str):
         file_info = self.global_view.get_insertion_by_file_name(file_name)


### PR DESCRIPTION
This makes the change to both fetching and queries.

Instead of merging the two components (sid + command) such as sid-fetch, now these two components are separate.

For Example
/<repo_prefix>/query/files    ==>>   /<repo_prefix>/query/files
/<repo_prefix>/sid-query/query/files    ==>>   /<repo_prefix>/sid/<session_id>/query/files